### PR TITLE
Fix tvOS Bluetooth warning crash

### DIFF
--- a/Quake2-tvOS/Quake2-Info.plist
+++ b/Quake2-tvOS/Quake2-Info.plist
@@ -28,5 +28,7 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Automatic</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Quake II would like to remain connected to nearby bluetooth Game Controllers and Game Pads even when you’re not using the app.</string>
 </dict>
 </plist>

--- a/Quake2-tvOS/Quake2mp1-Info.plist
+++ b/Quake2-tvOS/Quake2mp1-Info.plist
@@ -28,5 +28,7 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Automatic</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Quake II would like to remain connected to nearby bluetooth Game Controllers and Game Pads even when you’re not using the app.</string>
 </dict>
 </plist>

--- a/Quake2-tvOS/Quake2mp2-Info.plist
+++ b/Quake2-tvOS/Quake2mp2-Info.plist
@@ -28,5 +28,7 @@
 	</array>
 	<key>UIUserInterfaceStyle</key>
 	<string>Automatic</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Quake II would like to remain connected to nearby bluetooth Game Controllers and Game Pads even when you’re not using the app.</string>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request fixes a crash on tvOS because of a missing `NSBluetoothAlwaysUsageDescription` key in the tvOS info Info.plist. The key from the iOS Info.plist file has been copied.

> This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSBluetoothAlwaysUsageDescription key with a string value explaining to the user how the app uses this data.