### PR TITLE
Various UI improvements

### DIFF
--- a/Quake2-iOS.xcodeproj/project.pbxproj
+++ b/Quake2-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4C963DDC26BB446500F43256 /* JoyStickViewMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C963DDB26BB446400F43256 /* JoyStickViewMonitor.swift */; };
+		4C963DDD26BB447000F43256 /* JoyStickViewMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C963DDB26BB446400F43256 /* JoyStickViewMonitor.swift */; };
+		4C963DDE26BB447100F43256 /* JoyStickViewMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C963DDB26BB446400F43256 /* JoyStickViewMonitor.swift */; };
+		4C963DDF26BB447200F43256 /* JoyStickViewMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C963DDB26BB446400F43256 /* JoyStickViewMonitor.swift */; };
 		A132345A2209FFE200884138 /* Quake2mp1LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A13234582209FFD000884138 /* Quake2mp1LaunchScreen.storyboard */; };
 		A132345B2209FFE500884138 /* Quake2mp2LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A13234592209FFD000884138 /* Quake2mp2LaunchScreen.storyboard */; };
 		A142F96922138D03006A2A17 /* SavedGameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A142F96822138D02006A2A17 /* SavedGameViewController.swift */; };
@@ -1088,6 +1092,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4C963DDB26BB446400F43256 /* JoyStickViewMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoyStickViewMonitor.swift; sourceTree = "<group>"; };
 		8D1107310486CEB800E47090 /* Quake2-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Quake2-Info.plist"; sourceTree = "<group>"; };
 		A13234582209FFD000884138 /* Quake2mp1LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Quake2mp1LaunchScreen.storyboard; sourceTree = "<group>"; };
 		A13234592209FFD000884138 /* Quake2mp2LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Quake2mp2LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -2351,6 +2356,7 @@
 				A1C1267C220908DF00EAD9CB /* Extensions.swift */,
 				A15BF75F21FD0819005F4B74 /* GameViewController.swift */,
 				A1C1205621FE821900EAD9CB /* JoyStickView.swift */,
+				4C963DDB26BB446400F43256 /* JoyStickViewMonitor.swift */,
 				A15BF74A21FCF7E3005F4B74 /* Main.storyboard */,
 				A15BF75D21FD0604005F4B74 /* MainMenuViewController.swift */,
 				A16571B8220B9FD900FE9FC9 /* OptionsViewController.swift */,
@@ -3518,6 +3524,7 @@
 				A15BF73521FCDD7A005F4B74 /* sdl.c in Sources */,
 				A15BF64521FCDD7A005F4B74 /* supertank.c in Sources */,
 				A15BF67D21FCDD7A005F4B74 /* cmdparser.c in Sources */,
+				4C963DDC26BB446500F43256 /* JoyStickViewMonitor.swift in Sources */,
 				A1C1267D220908DF00EAD9CB /* Extensions.swift in Sources */,
 				A15BF65121FCDD7A005F4B74 /* flipper.c in Sources */,
 				A15BF70721FCDD7A005F4B74 /* gl3_surf.c in Sources */,
@@ -3755,6 +3762,7 @@
 				A1C1237E2203B37600EAD9CB /* cl_network.c in Sources */,
 				A1C123802203B37600EAD9CB /* videomenu.c in Sources */,
 				A1C124052203B4B400EAD9CB /* medic.c in Sources */,
+				4C963DDE26BB447100F43256 /* JoyStickViewMonitor.swift in Sources */,
 				A1C123832203B37600EAD9CB /* CoreGraphics+Additions.swift in Sources */,
 				A1C123E92203B49200EAD9CB /* g_monster.c in Sources */,
 				A1C123F02203B49200EAD9CB /* g_utils.c in Sources */,
@@ -3946,6 +3954,7 @@
 				A1C1247F2203FE2600EAD9CB /* unzip.c in Sources */,
 				A1C124F72203FF4900EAD9CB /* client.c in Sources */,
 				A1C124802203FE2600EAD9CB /* frame.c in Sources */,
+				4C963DDF26BB447200F43256 /* JoyStickViewMonitor.swift in Sources */,
 				A1C124812203FE2600EAD9CB /* misc.c in Sources */,
 				A1C124DF2203FF2D00EAD9CB /* boss31.c in Sources */,
 				A1C124822203FE2600EAD9CB /* argproc.c in Sources */,
@@ -4336,6 +4345,7 @@
 				A1F1116A23F740E10030D586 /* sw_main.c in Sources */,
 				A1F110C823F740B00030D586 /* qmenu.c in Sources */,
 				A1F110C923F740B00030D586 /* cvar.c in Sources */,
+				4C963DDD26BB447000F43256 /* JoyStickViewMonitor.swift in Sources */,
 				A1F110CA23F740B00030D586 /* netchan.c in Sources */,
 				A1F1116423F740E10030D586 /* sw_aclip.c in Sources */,
 				A1F110CB23F740B00030D586 /* system.c in Sources */,

--- a/Quake2-iOS/JoyStickView.swift
+++ b/Quake2-iOS/JoyStickView.swift
@@ -1,59 +1,83 @@
+// Copyright © 2020 Brad Howes. All rights reserved.
+
 import UIKit
 import CoreGraphics
-
-
-protocol JoystickDelegate: class {
-    
-    func handleJoyStick(angle: CGFloat, displacement: CGFloat)
-    func handleJoyStickPosition(x: CGFloat, y: CGFloat)
-
-}
-
-
-/**
- Type definition for a function that will receive updates from the JoyStickView when the handle moves. Takes two
- values, both CGFloats.
- - parameter angle: the direction the handle is pointing. Unit is degrees with 0° pointing up (north), and 90° pointing
- right (east).
- - parameter displacement: how far from the view center the joystick is moved in the above direction. Unitless but
- is the ratio of distance moved from center over the radius of the joystick base. Always in range 0.0-1.0
- */
-public typealias JoyStickViewMonitor = (_ angle: CGFloat, _ displacement: CGFloat) -> ()
 
 /**
  A simple implementation of a joystick interface like those found on classic arcade games. This implementation detects
  and reports two values when the joystick moves:
- 
+
  * angle: the direction the handle is pointing. Unit is degrees with 0° pointing up (north), and 90° pointing
  right (east).
  * displacement: how far from the view center the joystick is moved in the above direction. Unitless but
  is the ratio of distance moved from center over the radius of the joystick base. Always in range 0.0-1.0
- 
- The view has two settable parameters:
- 
- * monitor: a function of type `JoyStickViewMonitor` that will receive updates when the joystick's angle and/or
- displacement values change.
- * movable: a boolean that when true lets the joystick move around in its parent's view when there joystick moves
+
+ The view has several settable parameters that be used to configure a joystick's appearance and behavior:
+
+ - monitor: an enumeration of type `JoyStickViewMonitorKind` that can hold a function to receive updates when the
+ joystick's angle and/or displacement values change. Supports polar and cartesian (XY) reporting
+ - movable: a boolean that when true lets the joystick move around in its parent's view when there joystick moves
  beyond displacement of 1.0.
+ - movableBounds: a CGRect which limits where a movable joystick may travel
+ - baseImage: a UIImage to use for the joystick's base
+ - handleImage: a UIImage to use for the joystick's handle
  
+ Additional documentation is available via the attribute names below.
  */
-public final class JoyStickView: UIView {
-    
-    var delegate: JoystickDelegate?
-    
-    // override class var requiresConstraintBasedLayout: Bool { return true }
-    
-    /// Holds a function to call when joystick orientation changes
-    public var monitor: JoyStickViewMonitor? = nil
-    
+@IBDesignable public final class JoyStickView: UIView {
+
+    /// Optional monitor which will receive updates as the joystick position changes. Supports polar and cartesian
+    /// reporting. The function to call with a position report is held in the enumeration value.
+    public var monitor: JoyStickViewMonitorKind = .none
+
+    /// Optional rectangular region that restricts where the handle may move. The region should be defined in
+    /// this view's coordinates. For instance, to constrain the handle in the Y direction with a UIView of size 100x100,
+    /// use `CGRect(x: 50, y: 0, width: 1, height: 100)`
+    public var handleConstraint: CGRect? {
+        didSet {
+            switch handleConstraint {
+            case .some(let hc):
+                handleCenterClamper = { CGPoint(x: min(max($0.x, hc.minX), hc.maxX),
+                                                y: min(max($0.y, hc.minY), hc.maxY)) }
+            default:
+                handleCenterClamper = { $0 }
+            }
+        }
+    }
+
+    /// The last-reported angle from the joystick handle. Unit is degrees, with 0° up (north) and 90° right (east).
+    /// Note that this assumes that `angleRadians` was calculated with atan2(dx, dy) and that dy is positive when
+    /// pointing down.
+    public var angle: CGFloat { return displacement != 0.0 ? 180.0 - angleRadians * 180.0 / .pi : 0.0 }
+
+    /// The last-reported displacement from the joystick handle. Dimensionless but is the ratio of movement over
+    /// the radius of the joystick base. Always falls between 0.0 and 1.0
+    public private(set) var displacement: CGFloat = 0.0
+
     /// If `true` the joystick will move around in the parant's view so that the joystick handle is always at a
     /// displacement of 1.0. This is the default mode of operation. Setting to `false` will keep the view fixed.
-    public var movable: Bool = true
-    public var movableBounds: CGRect?
-    
-    /// The opacity of the base of the joystick. Note that this is different than the view's overall opacity setting.
-    /// The end result will be a base image with an opacity of `baseAlpha` * `view.alpha`
-    public var baseAlpha: CGFloat {
+    @IBInspectable public var movable: Bool = false
+
+    /// The original location of a movable joystick. Used to restore its position when user double-taps on it.
+    public var movableCenter: CGPoint? = nil
+
+    /// Optional rectangular region that restricts where the base may move. The region should be defined in the
+    /// this view's coordinates.
+    public var movableBounds: CGRect? {
+        didSet {
+            switch movableBounds {
+            case .some(let mb):
+                baseCenterClamper = { CGPoint(x: min(max($0.x, mb.minX), mb.maxX),
+                                              y: min(max($0.y, mb.minY), mb.maxY)) }
+            default:
+                baseCenterClamper = { $0 }
+            }
+        }
+    }
+
+    /// The opacity of the base of the joystick. Note that this is different than the view's overall opacity
+    /// setting. The end result will be a base image with an opacity of `baseAlpha` * `view.alpha`
+    @IBInspectable public var baseAlpha: CGFloat {
         get {
             return baseImageView.alpha
         }
@@ -61,43 +85,94 @@ public final class JoyStickView: UIView {
             baseImageView.alpha = newValue
         }
     }
-    
-    /// The tintColor to apply to the handle. By default, uses the view's tintColor value. Changing it while joystick
-    /// is visible will update the handle image.
-    public var handleTintColor: UIColor! {
-        didSet { makeHandleImage() }
+
+    /// The opacity of the handle of the joystick. Note that this is different than the view's overall opacity setting.
+    /// The end result will be a handle image with an opacity of `handleAlpha` * `view.alpha`
+    @IBInspectable public var handleAlpha: CGFloat {
+        get {
+            return handleImageView.alpha
+        }
+        set {
+            handleImageView.alpha = newValue
+        }
     }
-    
-    /// The last-reported angle from the joystick handle. Unit is degrees, with 0° up (north) and 90° right (east)
-    public private(set) var angle: CGFloat = 0.0
-    
-    /// The last-reported displacement from the joystick handle. Dimensionless but is the ratio of movement over
-    /// the radius of the joystick base. Always falls between 0.0 and 1.0
-    public private(set) var displacement: CGFloat = 0.0
-    
-    /// The radius of the base of the joystick, the max distance the handle may move in any direction.
-    private lazy var radius: CGFloat = { return self.bounds.size.width / 2.0 }()
-    
+
+    /// The tintColor to apply to the handle. Changing it while joystick is visible will update the handle image.
+    @IBInspectable public var handleTintColor: UIColor? = nil {
+        didSet { generateHandleImage() }
+    }
+
+    /// Scaling factor to apply to the joystick handle. A value of 1.0 will result in no scaling of the image,
+    /// however the default value is 0.85 due to historical reasons.
+    @IBInspectable public var handleSizeRatio: CGFloat = 0.85 {
+        didSet {
+            scaleHandleImageView()
+        }
+    }
+
+    /// Control how the handle image is generated. When this is `false` (default), a CIFilter will be used to tint
+    /// the handle image with the `handleTintColor`. This results in a monochrome image of just one color, but with
+    /// lighter and darker areas depending on the original image. When this is `true`, the handle image is just
+    /// used as a mask, and all pixels with an alpha = 1.0 will be colored with the `handleTintColor` value.
+    @IBInspectable public var colorFillHandleImage: Bool = false {
+        didSet { generateHandleImage() }
+    }
+
+    /// Controls how far the handle can travel along the radius of the base. A value of 1.0 (default) will let the
+    /// handle travel the full radius, with maximum travel leaving the center of the handle lying on the circumference
+    /// of the base. A value greater than 1.0 will let the handle travel beyond the circumference of the base, while a
+    /// value less than 1.0 will reduce the travel to values within the circumference. Note that regardless of this
+    /// value, handle movements will always report displacement values between 0.0 and 1.0 inclusive.
+    @IBInspectable public var travel: CGFloat = 1.0
+
     /// The image to use for the base of the joystick
-    private let baseImage = UIImage(named: "JoyStickBase")!
-    
+    @IBInspectable public var baseImage: UIImage? {
+        didSet { baseImageView.image = baseImage }
+    }
+
     /// The image to use for the joystick handle
-    private let handleImage = UIImage(named: "JoyStickHandle")!
+    @IBInspectable public var handleImage: UIImage? {
+        didSet { generateHandleImage() }
+    }
+
+    /// Control whether view will recognize a double-tap gesture and move the joystick base to its original location
+    /// when it happens. Note that this is only useful if `moveable` is true.
+    @IBInspectable public var enableDoubleTapForFrameReset = true {
+        didSet {
+            if let dtgr = doubleTapGestureRecognizer {
+                removeGestureRecognizer(dtgr)
+                doubleTapGestureRecognizer = nil
+            }
+            if enableDoubleTapForFrameReset {
+                installDoubleTapGestureRecognizer()
+            }
+        }
+    }
+
+    /// The max distance the handle may move in any direction, where the start is the center of the joystick base and
+    /// the end is on the circumference of the base when travel is 1.0.
+    private var radius: CGFloat { return self.bounds.size.width / 2.0 * travel }
     
     /// The image to use to show the base of the joystick
-    private var baseImageView: UIImageView!
-    
+    private var baseImageView: UIImageView = UIImageView(image: nil)
+
     /// The image to use to show the handle of the joystick
-    private var handleImageView: UIImageView!
-    
+    private var handleImageView: UIImageView = UIImageView(image: nil)
+
     /// Cache of the last joystick angle in radians
-    private var lastAngleRadians: Float = 0.0
-    
-    /// The original location of the joystick. Used to restore its position when user double-taps on it.
-    private var originalCenter: CGPoint?
-    
+    private var angleRadians: CGFloat = 0.0
+
     /// Tap gesture recognizer for double-taps which will reset the joystick position
-    private var tapGestureRecognizer: UITapGestureRecognizer!
+    private var tapGestureRecognizer: UITapGestureRecognizer?
+
+    /// A filter for joystick base centers. Used to restrict base movements.
+    private var baseCenterClamper: (CGPoint) -> CGPoint = { $0 }
+
+    /// A filter for joystick handle centers. Used to restrict handle movements.
+    private var handleCenterClamper: (CGPoint) -> CGPoint = { $0 }
+
+    /// Tap gesture recognizer for detecting double-taps. Only present if `enableDoubleTapForFrameReset` is true
+    private var doubleTapGestureRecognizer: UITapGestureRecognizer?
     
     /**
      Initialize new joystick view using the given frame.
@@ -105,63 +180,35 @@ public final class JoyStickView: UIView {
      */
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        initialize()
     }
-    
+
     /**
      Initialize new joystick view from a file.
      - parameter coder: the source of the joystick configuration information
      */
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+
+    /**
+     This is the appropriate place to configure our internal views as we have our own geometry.
+     */
+    public override func layoutSubviews() {
+        super.layoutSubviews()
         initialize()
     }
-    
-    /**
-     Common initialization of view. Creates UIImageView instances for base and handle.
-     */
-    private func initialize() {
-        
-        handleTintColor = tintColor
-        
-        baseImageView = UIImageView(image: baseImage)
-        baseImageView.alpha = baseAlpha
-        addSubview(baseImageView)
-        baseImageView.frame = bounds
-        
-        handleImageView = UIImageView(image: handleImage)
-        makeHandleImage()
-        addSubview(handleImageView)
-        handleImageView.frame = bounds.insetBy(dx: 0.15 * bounds.width, dy: 0.15 * bounds.height)
-        
-        tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(resetFrame))
-        tapGestureRecognizer!.numberOfTapsRequired = 2
-        addGestureRecognizer(tapGestureRecognizer!)
-    }
-    
-    /**
-     Generate a new handle image using the current `tintColor` value and install. Uses CoreImage filter to apply a
-     tint to the grey handle image.
-     */
-    private func makeHandleImage() {
-        guard handleImageView != nil else { return }
-        guard let inputImage = CIImage(image: handleImage) else {
-            fatalError("failed to create input CIImage")
-        }
-        
-        let filterConfig: [String:Any] = [kCIInputIntensityKey: 1.0,
-                                          kCIInputColorKey: CIColor(color: handleTintColor!),
-                                          kCIInputImageKey: inputImage]
-        guard let filter = CIFilter(name: "CIColorMonochrome", parameters: filterConfig) else {
-            fatalError("failed to create CIFilter CIColorMonochrome")
-        }
-        
-        guard let outputImage = filter.outputImage else {
-            fatalError("failed to obtain output CIImage")
-        }
-        
-        handleImageView.image = UIImage(ciImage: outputImage)
-    }
+}
+
+// MARK: - Touch Handling
+
+/**
+ Main recognizer for movement
+ 
+    We use a recognizer rather than the view's own touch handler methods as there is an iOS quirk
+    that delays the touchesEnded method. This quirk doesn't apply to gesture recognizers.
+ */
+class JoyStickViewGestureRecognizer: UIGestureRecognizer {
+    private var touch: UITouch?
     
     /**
      A touch began in the joystick view
@@ -169,8 +216,8 @@ public final class JoyStickView: UIView {
      - parameter event: additional event info (ignored)
      */
     public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard let touch = touches.first else { return }
-        updatePosition(touch: touch)
+        touch = touches.first
+        state = .began
     }
     
     /**
@@ -179,10 +226,9 @@ public final class JoyStickView: UIView {
      - parameter event: additional event info (ignored)
      */
     public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard let touch = touches.first else { return }
-        updatePosition(touch: touch)
+        state = .changed
     }
-    
+
     /**
      An existing touch event has been cancelled (probably due to system event such as an alert). Move joystick to
      center of base.
@@ -190,41 +236,165 @@ public final class JoyStickView: UIView {
      - parameter event: additional event info (ignored)
      */
     public override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
-        resetPosition()
+        state = .ended
+        touch = nil
     }
-    
+
     /**
      User removed touch from display. Move joystick to center of base.
      - parameter touches: the set of UITouch instances, one for each touch event (ignored)
      - parameter event: additional event info (ignored)
      */
     public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        resetPosition()
+        state = .ended
+        touch = nil
     }
     
     /**
-     Reset our position.
+     Get touch location
+     - parameter view: the view in which to return location coordinates
      */
-    @objc public func resetFrame() {
-        if displacement < 0.5 && originalCenter != nil {
-            center = originalCenter!
-            originalCenter = nil
+    public override func location(in view: UIView?) -> CGPoint {
+        guard touch != nil else { return .zero }
+        return touch!.location(in: view)
+    }
+}
+
+extension JoyStickView {
+    @objc private func gestureRecognizerChanged(recognizer: JoyStickViewGestureRecognizer) {
+        if recognizer.state == .began || recognizer.state == .changed {
+            updateLocation(location: recognizer.location(in: superview!))
+        } else if recognizer.state == .ended {
+            homePosition()
         }
     }
     
     /**
-     Reset handle position so that it is in the center of the base.
+     Reset our base to the initial location before the user moved it. By default, this will take place
+     whenever the user double-taps on the joystick handle.
      */
-    private func resetPosition() {
-        updateLocation(location: CGPoint(x: frame.midX, y: frame.midY))
+    @objc public func resetFrame() {
+        guard let movableCenter = self.movableCenter, displacement < 0.5 else { return }
+        center = movableCenter
+    }
+}
+
+// MARK: - Implementation Details
+
+extension JoyStickView {
+    
+    /**
+     Common initialization of view. Creates UIImageView instances for base and handle.
+     */
+    private func initialize() {
+        baseImageView.frame = bounds
+        addSubview(baseImageView)
+
+        scaleHandleImageView()
+        addSubview(handleImageView)
+
+        let bundle = Bundle(for: JoyStickView.self)
+
+        if self.baseImage == nil {
+            if let baseImage = UIImage(named: "DefaultBase", in: bundle, compatibleWith: nil) {
+                self.baseImage = baseImage
+            }
+        }
+
+        baseImageView.image = baseImage
+
+        if self.handleImage == nil {
+            if let handleImage = UIImage(named: "DefaultHandle", in: bundle, compatibleWith: nil) {
+                self.handleImage = handleImage
+            }
+        }
+        
+        generateHandleImage()
+        
+        addGestureRecognizer(JoyStickViewGestureRecognizer(target: self, action: #selector(gestureRecognizerChanged)))
+        
+        if enableDoubleTapForFrameReset {
+            installDoubleTapGestureRecognizer()
+        }
+    }
+
+    private func scaleHandleImageView() {
+        let inset = (1.0 - handleSizeRatio) * bounds.width / 2.0
+        handleImageView.frame = bounds.insetBy(dx: inset, dy: inset)
     }
     
     /**
-     Update the handle position based on the current touch location.
-     - parameter touch: the UITouch instance describing where the finger/pencil is
+     Install a UITapGestureRecognizer to detect and process double-tap activity on the joystick.
      */
-    private func updatePosition(touch: UITouch) {
-        updateLocation(location: touch.location(in: superview!))
+    private func installDoubleTapGestureRecognizer() {
+        tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(resetFrame))
+        tapGestureRecognizer!.numberOfTapsRequired = 2
+        addGestureRecognizer(tapGestureRecognizer!)
+    }
+
+    private func generateHandleImage() {
+        if colorFillHandleImage {
+            colorHandleImage()
+        }
+        else {
+            tintHandleImage()
+        }
+    }
+    
+    /**
+     Generate a handle image by applying the `handleTintColor` value to the handeImage
+     */
+    private func colorHandleImage() {
+        guard let handleImage = self.handleImage else { return }
+        if let handleTintColor = self.handleTintColor {
+            let image = handleImage.withRenderingMode(.alwaysTemplate)
+            handleImageView.image = image
+            handleImageView.tintColor = handleTintColor
+        }
+        else {
+            handleImageView.tintColor = nil
+            handleImageView.image = handleImage
+        }
+    }
+    
+    private func tintHandleImage() {
+        guard let handleImage = self.handleImage else { return }
+
+        guard let handleTintColor = self.handleTintColor else {
+            handleImageView.image = handleImage
+            return
+        }
+
+        guard let inputImage = CIImage(image: handleImage) else {
+            fatalError("failed to create input CIImage")
+        }
+        
+        let filterConfig: [String:Any] = [kCIInputIntensityKey: 1.0,
+                                          kCIInputColorKey: CIColor(color: handleTintColor),
+                                          kCIInputImageKey: inputImage]
+        #if swift(>=4.2)
+        guard let filter = CIFilter(name: "CIColorMonochrome", parameters: filterConfig) else {
+            fatalError("failed to create CIFilter CIColorMonochrome")
+        }
+        #else
+        guard let filter = CIFilter(name: "CIColorMonochrome", withInputParameters: filterConfig) else {
+            fatalError("failed to create CIFilter CIColorMonochrome")
+        }
+        #endif
+        
+        guard let outputImage = filter.outputImage else {
+            fatalError("failed to obtain output CIImage")
+        }
+        
+        handleImageView.image = UIImage(ciImage: outputImage)
+    }
+
+    /**
+     Reset handle position so that it is in the center of the base.
+     */
+    private func homePosition() {
+        handleImageView.center = bounds.mid
+        reportPosition()
     }
     
     /**
@@ -235,151 +405,109 @@ public final class JoyStickView: UIView {
     private func updateLocation(location: CGPoint) {
         guard let superview = self.superview else { return }
         guard superview.bounds.contains(location) else { return }
-        
-        // Calculate displacements between given location and our frame's center
-        //
+
         let delta = location - frame.mid
-        
-        // Calculate normalized displacement
-        //
         let newDisplacement = delta.magnitude / radius
-//        print("********")
-//        print("delta.magnitude: \(delta.magnitude) radius: \(radius) newDisplacement: \(newDisplacement)")
 
         // Calculate pointing angle used displacements. NOTE: using this ordering of dx, dy to atan2f to obtain
-        // navigation angles where 0 is at top of clock dial and angle values increase in a clock-wise direction.
+        // navigation angles where 0 is at top of clock dial and angle values increase in a clock-wise direction. This
+        // also assumes that Y increases in the downward direction.
         //
-        let newAngleRadians = atan2f(Float(delta.dx), Float(delta.dy))
-        
+        let newAngleRadians = atan2(delta.dx, delta.dy)
+
         if movable {
-            if newDisplacement > 1.0 {
-                
-                if originalCenter == nil {
-                    originalCenter = center
-                }
-                
-                // Calculate point that should be on the circumference of the base image.
-                //
-                let end = CGVector(dx: CGFloat(sinf(newAngleRadians)) * radius,
-                                   dy: CGFloat(cosf(newAngleRadians)) * radius)
-                
-                // Calculate the origin of our frame, working backwards from the given location, and move to it.
-                //
-                let origin = location - end - frame.size / 2.0
-                
-                if movableBounds != nil {
-                    frame.origin = CGPoint(x: min(max(origin.x, movableBounds!.minX), movableBounds!.maxX - frame.width),
-                                           y: min(max(origin.y, movableBounds!.minY), movableBounds!.maxY - frame.height))
-                }
-                else {
-                    frame.origin = origin
-                }
-            }
-            
-            // Update location of handle
-            //
-            handleImageView.center = bounds.mid + delta
-        }
-        else {
-            
-            // Update location of handle
-            //
-            if newDisplacement > 1.0 {
-                
-                // Keep handle on the circumference of the base image
-                //
-                let x = CGFloat(sinf(newAngleRadians)) * radius
-                let y = CGFloat(cosf(newAngleRadians)) * radius
-                handleImageView.frame.origin = CGPoint(x: x + bounds.midX - handleImageView.bounds.size.width / 2.0,
-                                                       y: y + bounds.midY - handleImageView.bounds.size.height / 2.0)
+            if newDisplacement > 1.0 && repositionBase(location: location, angle: newAngleRadians) {
+                repositionHandle(angle: newAngleRadians)
             }
             else {
-                handleImageView.center = bounds.mid + delta
+                handleImageView.center = handleCenterClamper(bounds.mid + delta)
             }
         }
-        
-        // Update joystick reporting values
-        //
-        let newClampedDisplacement = min(newDisplacement, 1.0)
-        if newClampedDisplacement != displacement || newAngleRadians != lastAngleRadians {
-            displacement = newClampedDisplacement
-            lastAngleRadians = newAngleRadians
-            
-            // Convert to degrees: 0° is up, 90° is right, 180° is down and 270° is left
-            //
-            self.angle = newClampedDisplacement != 0.0 ? CGFloat(180.0 - newAngleRadians * 180.0 / Float.pi) : 0.0
-            //            monitor?(angle, displacement)
-            self.delegate?.handleJoyStick(angle: angle, displacement: displacement)
-            
-            
-//            print("delta x: \(delta.dx) delta y: \(delta.dy)")
-            
-            let new_x = (delta.dx / (radius * 2))
-            let new_y = (delta.dy / (radius * 2)) * -1
-//            print("new_x: \(new_x) new_y: \(new_y)")
-            self.delegate?.handleJoyStickPosition(x: new_x, y: new_y)
+        else if newDisplacement > 1.0 {
+            repositionHandle(angle: newAngleRadians)
         }
+        else {
+            handleImageView.center = handleCenterClamper(bounds.mid + delta)
+        }
+
+        reportPosition()
+    }
+
+    /**
+     Report the current joystick values to any registered `monitor`.
+     */
+    private func reportPosition() {
+        let delta = handleImageView.center - baseImageView.center
+        let displacement = delta.magnitude2 == 0.0 ? 0.0 : delta.magnitude / radius
+        let angleRadians = delta.magnitude2 == 0.0 ? 0.0 : atan2(delta.dx, delta.dy)
+
+        self.displacement = displacement
+        self.angleRadians = angleRadians
+            
+        switch monitor {
+        case let .polar(monitor): monitor(JoyStickViewPolarReport(angle: self.angle, displacement: displacement))
+        case let .xy(monitor): monitor(JoyStickViewXYReport(x: delta.dx, y: -delta.dy))
+        case .none: break
+        }
+    }
+    
+    /**
+     Move the base so that the handle displacement is <= 1.0 from the base. THe last step of this operation is
+     a clamping of the base origin so that it stays within a configured boundary. Such clamping can result in
+     a joystick handle whose displacement is > 1.0 from the base, so the caller should account for that by looking
+     for a `true` return value.
+    
+     - parameter location: the current joystick handle center position
+     - parameter angle: the angle the handle makes with the center of the base
+     - returns: true if the base **cannot** move sufficiently to keep the displacement of the handle <= 1.0
+     */
+    private func repositionBase(location: CGPoint, angle: CGFloat) -> Bool {
+        if movableCenter == nil {
+            movableCenter = self.center
+        }
+
+        // Calculate point that should be on the circumference of the base image.
+        //
+        let end = CGVector(dx: sin(angle) * radius, dy: cos(angle) * radius)
+
+        // Calculate the origin of our frame, working backwards from the given location, and move to it.
+        //
+        let desiredCenter = location - end //  - frame.size / 2.0
+        self.center = baseCenterClamper(desiredCenter)
+        return self.center != desiredCenter
+    }
+
+    /**
+     Move the joystick handle so that the angle made up of the triangle from the base 12:00 position on its
+     circumference, the base center and the joystick center is the given value.
+    
+     - parameter angle: the angle (radians) to conform to
+     */
+    private func repositionHandle(angle: CGFloat) {
+
+        // Keep handle on the circumference of the base image
+        //
+        let x = sin(angle) * radius
+        let y = cos(angle) * radius
+        handleImageView.frame.origin = CGPoint(x: x + bounds.midX - handleImageView.bounds.size.width / 2.0,
+                                               y: y + bounds.midY - handleImageView.bounds.size.height / 2.0)
+        
+        handleImageView.center = handleCenterClamper(handleImageView.center)
     }
 }
 
-public func LiangBarsky(rect: CGRect, p0: CGPoint, p1: CGPoint) -> (p0: CGPoint, p1: CGPoint, inRect: Bool) {
-    let edgeLeft = rect.minX
-    let edgeRight = rect.maxX
-    let edgeBottom = rect.minY
-    let edgeTop = rect.maxY
-    
-    var t0: CGFloat = 0.0
-    var t1: CGFloat = 1.0
-    let xd = p1.x - p0.x
-    let yd = p1.y - p0.y
-    let cases = [(-xd, -(edgeLeft -   p0.x)),
-                 ( xd,   edgeRight -  p0.x),
-                 (-yd, -(edgeBottom - p0.y)),
-                 ( yd,   edgeTop -    p0.y)]
-    
-    // Check edges against the appropriate coordinate delta
-    //
-    let epsilon: CGFloat = 1.0e-8
-    
-    for (p, q) in cases {
-        
-        // Protect from explosion when calculating 'r' below with 'p' in denominator
-        //
-        if abs(p) < epsilon {
-            if q < 0.0 {
-                
-                // Horizontal or vertical line that is outside of the rectangle
-                //
-                return (p0: p0, p1: p1, inRect: false)
-            }
-        }
-        else {
-            
-            // Safe to do since 'p' is not zero here. However, maybe we should do better since very small 'p' will lead
-            // to a very large 'r'. We can do 'q > t1 * p' for instance in the condition below, but we then need to
-            // change use of 't0' in the parametric equation at the bottom.
-            //
-            let r: CGFloat = q / p
-            if p < 0.0 {
-                if r > t1 {
-                    return (p0: p0, p1: p1, inRect: false)
-                }
-                else if r > t0 {
-                    t0 = r
-                }
-            }
-            else if p > 0.0 {
-                if r < t0 {
-                    return (p0: p0, p1: p1, inRect: false)
-                }
-                else if r < t1 {
-                    t1 = r
-                }
-            }
-        }
+/**
+ Provide support for Obj-C monitors by wrapping a block in a closure that works with the Swift-only types.
+ */
+extension JoyStickView {
+
+    @objc public func setPolarMonitor(_ block: @escaping (CGFloat, CGFloat) -> Void) {
+        let bridge = {(report: JoyStickViewPolarReport) in block(report.angle, report.displacement) }
+        monitor = .polar(monitor: bridge)
     }
-    
-    return (p0: CGPoint(x: p0.x + t0 * xd, y: p0.y + t0 * yd),
-            p1: CGPoint(x: p0.x + t1 * xd, y: p0.y + t1 * yd),
-            inRect: true)
+
+    @objc public func setXYMonitor(_ block: @escaping (CGFloat, CGFloat) -> Void) {
+        let bridge = {(report: JoyStickViewXYReport) in block(report.x, report.y) }
+        monitor = .xy(monitor: bridge)
+    }
 }

--- a/Quake2-iOS/JoyStickViewMonitor.swift
+++ b/Quake2-iOS/JoyStickViewMonitor.swift
@@ -1,0 +1,93 @@
+// Copyright © 2020 Brad Howes. All rights reserved.
+
+import CoreGraphics
+
+/**
+ JoyStickView handle position as X, Y deltas from the base center. Note that here a positive `y` indicates that the
+ joystick handle is pushed upwards.
+ */
+public struct JoyStickViewXYReport {
+    /// Delta X of handle from base center
+    public let x: CGFloat
+    /// Delta Y of handle from base center
+    public let y: CGFloat
+
+    /**
+     Constructor of new XY report
+    
+     - parameter x: X offset from center of the base
+     - parameter y: Y offset from center of the base (positive values towards up/north)
+     */
+    public init(x: CGFloat, y: CGFloat) {
+        self.x = x
+        self.y = y
+    }
+ 
+    /// Convert this report into polar format
+    public var polar: JoyStickViewPolarReport {
+        return JoyStickViewPolarReport(angle: (180.0 - atan2(x, -y) * 180.0 / .pi), displacement: sqrt(x * x + y * y))
+    }
+}
+
+/**
+ JoyStickView handle position as angle/displacement values from the base center. Note that `angle` is given in degrees,
+ with 0° pointing up (north) and 90° pointing right (east).
+ */
+public struct JoyStickViewPolarReport {
+    /// Clockwise angle of the handle with respect to north/up of 0°.
+    public let angle: CGFloat
+    /// Distance from the center of the base
+    public let displacement: CGFloat
+
+    /**
+     Constructor of new polar report
+    
+     - parameter angle: clockwise angle of the handle with respect to north/up of 0°.
+     - parameter displacement: distance from the center of the base
+     */
+    public init(angle: CGFloat, displacement: CGFloat) {
+        self.angle = angle
+        self.displacement = displacement
+    }
+    
+    /// Convert this report into XY format
+    public var rectangular: JoyStickViewXYReport {
+        let rads = angle * .pi / 180.0
+        return JoyStickViewXYReport(x: sin(rads) * displacement, y: cos(rads) * displacement)
+    }
+}
+
+/**
+ Prototype of a monitor function that accepts a JoyStickViewXYReport.
+ */
+public typealias JoyStickViewXYMonitor = (_ value: JoyStickViewXYReport) -> Void
+
+/**
+ Prototype of a monitor function that accepts a JoyStickViewXYReport.
+ */
+public typealias JoyStickViewPolarMonitor = (_ value: JoyStickViewPolarReport) -> Void
+
+/**
+ Monitor kind. Determines the type of reporting that will be emitted from a JoyStickView instance.
+ */
+public enum JoyStickViewMonitorKind {
+    
+    /**
+     Install monitor that accepts polar position change reports
+     
+     - parameter monitor: function that accepts a JoyStickViewPolarReport
+     */
+    case polar(monitor: JoyStickViewPolarMonitor)
+
+    /**
+     Install monitor that accepts cartesian (XY) position change reports
+     
+     - parameter monitor: function that accepts a JoyStickViewXYReport
+     */
+    case xy(monitor: JoyStickViewXYMonitor)
+    
+    /**
+     No monitoring for a JoyStickView instance.
+     */
+    case none
+}

--- a/Quake2-iOS/Main.storyboard
+++ b/Quake2-iOS/Main.storyboard
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="B6S-26-QQH">
-    <device id="retina5_9" orientation="landscape">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="B6S-26-QQH">
+    <device id="retina5_9" orientation="landscape" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -30,7 +27,7 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Eor-e5-7M8">
-                                <rect key="frame" x="308.33333333333326" y="0.0" width="439.66666666666674" height="234.66666666666666"/>
+                                <rect key="frame" x="312.33333333333326" y="0.0" width="439.66666666666674" height="234.66666666666666"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="q u a k e  ii" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i1s-G9-Y44">
                                         <rect key="frame" x="0.0" y="0.0" width="439.66666666666669" height="84.666666666666671"/>
@@ -50,7 +47,7 @@
                                         <color key="textColor" red="0.52549019610000003" green="0.86666666670000003" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tdG-Gj-xg9">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tdG-Gj-xg9">
                                         <rect key="frame" x="0.0" y="84.666666666666671" width="439.66666666666669" height="50.000000000000014"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="50" id="oxc-yM-MIu"/>
@@ -63,7 +60,7 @@
                                             <segue destination="h0z-nt-sVd" kind="show" id="tvD-Vk-2Ys"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aSs-6i-98s">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aSs-6i-98s">
                                         <rect key="frame" x="0.0" y="134.66666666666666" width="439.66666666666669" height="50"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="50" id="a58-um-cvu"/>
@@ -76,7 +73,7 @@
                                             <segue destination="Crn-DM-9m3" kind="show" id="tHY-Am-x4g"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cg6-2x-SRT">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cg6-2x-SRT">
                                         <rect key="frame" x="0.0" y="184.66666666666666" width="439.66666666666669" height="50"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="50" id="Q7x-qo-cjy"/>
@@ -91,7 +88,7 @@
                                     </button>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pvT-lZ-3zr">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pvT-lZ-3zr">
                                 <rect key="frame" x="718" y="324" width="30" height="30"/>
                                 <state key="normal" title="π">
                                     <color key="titleColor" red="0.52549019610000003" green="0.86666666670000003" blue="0.69803921570000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -101,6 +98,7 @@
                                 </connections>
                             </button>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="qC1-tp-PXt"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="qC1-tp-PXt" firstAttribute="trailing" secondItem="pvT-lZ-3zr" secondAttribute="trailing" constant="20" id="4ef-nX-Fq2"/>
@@ -113,7 +111,6 @@
                             </constraint>
                             <constraint firstAttribute="bottom" secondItem="WE9-jb-ZdU" secondAttribute="bottom" id="hwM-co-d4n"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="qC1-tp-PXt"/>
                     </view>
                     <navigationItem key="navigationItem" id="bJL-Du-FQP"/>
                     <connections>
@@ -148,6 +145,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="0Y3-kc-ye4"/>
                         <color key="backgroundColor" red="0.52561199670000003" green="0.86642056700000003" blue="0.69806873800000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="iOI-0W-Afg" secondAttribute="bottom" constant="10" id="4WM-ih-oce"/>
@@ -157,7 +155,6 @@
                             <constraint firstItem="12b-vS-7K6" firstAttribute="leading" secondItem="zay-pc-Dpq" secondAttribute="leading" id="bdI-Zw-OIt"/>
                             <constraint firstItem="12b-vS-7K6" firstAttribute="centerY" secondItem="zay-pc-Dpq" secondAttribute="centerY" id="rw7-rJ-Efc"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="0Y3-kc-ye4"/>
                     </view>
                     <connections>
                         <outlet property="backgroundImage" destination="12b-vS-7K6" id="JTH-6T-f8N"/>
@@ -206,8 +203,8 @@
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pjo-ye-d46">
-                                <rect key="frame" x="20" y="310" width="101" height="45"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pjo-ye-d46">
+                                <rect key="frame" x="20" y="310" width="112" height="45"/>
                                 <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="28"/>
                                 <size key="titleShadowOffset" width="1" height="1"/>
                                 <state key="normal" title="&lt; BACK">
@@ -219,6 +216,7 @@
                                 </connections>
                             </button>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="f79-7j-LJI"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="DZj-0w-sPg" firstAttribute="leading" secondItem="f79-7j-LJI" secondAttribute="leading" constant="20" id="Bcp-LC-NL7"/>
@@ -228,7 +226,6 @@
                             <constraint firstAttribute="bottom" secondItem="Pjo-ye-d46" secondAttribute="bottom" constant="20" id="eBS-P5-hT9"/>
                             <constraint firstItem="DZj-0w-sPg" firstAttribute="top" secondItem="f79-7j-LJI" secondAttribute="top" constant="20" id="oUH-Xh-ykp"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="f79-7j-LJI"/>
                     </view>
                     <connections>
                         <outlet property="tiltAimingSwitch" destination="DZj-0w-sPg" id="Sj5-n6-x5F"/>
@@ -253,7 +250,7 @@
                                     <constraint firstAttribute="width" secondItem="clm-3X-Zgg" secondAttribute="height" multiplier="16:9" id="awC-8I-936"/>
                                 </constraints>
                             </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iIs-ln-FTU">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iIs-ln-FTU">
                                 <rect key="frame" x="20" y="310" width="112" height="45"/>
                                 <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="28"/>
                                 <size key="titleShadowOffset" width="1" height="1"/>
@@ -268,7 +265,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="f0f-y2-c2z">
                                 <rect key="frame" x="295" y="32" width="222" height="311"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="phz-D5-rfO">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="phz-D5-rfO">
                                         <rect key="frame" x="44" y="0.0" width="134" height="97"/>
                                         <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="72"/>
                                         <size key="titleShadowOffset" width="3" height="3"/>
@@ -279,7 +276,7 @@
                                             <action selector="easyDifficulty:" destination="h0z-nt-sVd" eventType="touchUpInside" id="SWc-lL-ahr"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FyM-ch-HqE">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FyM-ch-HqE">
                                         <rect key="frame" x="0.0" y="107" width="222" height="97"/>
                                         <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="72"/>
                                         <size key="titleShadowOffset" width="3" height="3"/>
@@ -290,7 +287,7 @@
                                             <action selector="normalDifficulty:" destination="h0z-nt-sVd" eventType="touchUpInside" id="oLS-CO-wj9"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8TW-h4-0A4">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8TW-h4-0A4">
                                         <rect key="frame" x="38.666666666666686" y="214" width="145" height="97"/>
                                         <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="72"/>
                                         <size key="titleShadowOffset" width="3" height="3"/>
@@ -304,6 +301,7 @@
                                 </subviews>
                             </stackView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="jIC-8m-7cF"/>
                         <color key="backgroundColor" red="0.52561199670000003" green="0.86642056700000003" blue="0.69806873800000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="iIs-ln-FTU" firstAttribute="leading" secondItem="BgP-W1-HJj" secondAttribute="leading" constant="20" id="AKp-Sl-r5m"/>
@@ -315,7 +313,6 @@
                             <constraint firstItem="f0f-y2-c2z" firstAttribute="centerY" secondItem="BgP-W1-HJj" secondAttribute="centerY" id="plM-VI-Tk2"/>
                             <constraint firstItem="clm-3X-Zgg" firstAttribute="centerX" secondItem="BgP-W1-HJj" secondAttribute="centerX" id="teV-hu-B6B"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="jIC-8m-7cF"/>
                     </view>
                     <connections>
                         <outlet property="backgroundImage" destination="clm-3X-Zgg" id="vCj-n7-wgO"/>
@@ -352,7 +349,7 @@
                                     <outlet property="delegate" destination="Crn-DM-9m3" id="gB1-mq-xIh"/>
                                 </connections>
                             </tableView>
-                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JGr-rQ-nlJ">
+                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JGr-rQ-nlJ">
                                 <rect key="frame" x="658" y="302" width="90" height="45"/>
                                 <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="28"/>
                                 <size key="titleShadowOffset" width="1" height="1"/>
@@ -364,7 +361,7 @@
                                     <segue destination="ZbM-Ov-oft" kind="show" identifier="LoadGameSegue" id="BYG-YZ-3MD"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ekb-oM-wIv">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ekb-oM-wIv">
                                 <rect key="frame" x="64" y="301" width="112" height="45"/>
                                 <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="28"/>
                                 <size key="titleShadowOffset" width="1" height="1"/>
@@ -377,6 +374,7 @@
                                 </connections>
                             </button>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="Ahe-VX-FSd"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="SOe-Tg-0Ox" firstAttribute="centerY" secondItem="G70-va-pDs" secondAttribute="centerY" id="0wZ-FC-bl6"/>
@@ -392,7 +390,6 @@
                             <constraint firstAttribute="trailing" secondItem="SOe-Tg-0Ox" secondAttribute="trailing" id="tMg-1T-DA9"/>
                             <constraint firstItem="Ahe-VX-FSd" firstAttribute="trailing" secondItem="Tob-r4-Kgp" secondAttribute="trailing" constant="20" id="v5o-Yz-h5T"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="Ahe-VX-FSd"/>
                     </view>
                     <connections>
                         <outlet property="backgroundImage" destination="SOe-Tg-0Ox" id="V2I-OM-kGW"/>
@@ -406,10 +403,10 @@
             <point key="canvasLocation" x="1001" y="1714"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="quake2background" width="1920" height="1080"/>
-    </resources>
     <inferredMetricsTieBreakers>
         <segue reference="BYG-YZ-3MD"/>
     </inferredMetricsTieBreakers>
+    <resources>
+        <image name="quake2background" width="1920" height="1080"/>
+    </resources>
 </document>

--- a/Quake2-iOS/Main.storyboard
+++ b/Quake2-iOS/Main.storyboard
@@ -341,9 +341,10 @@
                                     <constraint firstAttribute="width" secondItem="SOe-Tg-0Ox" secondAttribute="height" multiplier="16:9" id="dqG-Lt-h0r"/>
                                 </constraints>
                             </imageView>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Tob-r4-Kgp">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Tob-r4-Kgp">
                                 <rect key="frame" x="64" y="20" width="684" height="274"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <connections>
                                     <outlet property="dataSource" destination="Crn-DM-9m3" id="Z6u-u9-hPQ"/>
                                     <outlet property="delegate" destination="Crn-DM-9m3" id="gB1-mq-xIh"/>

--- a/Quake2-iOS/SDL_uikitviewcontroller+Additions.swift
+++ b/Quake2-iOS/SDL_uikitviewcontroller+Additions.swift
@@ -234,6 +234,11 @@ extension SDL_uikitviewcontroller {
             cl_joyscale.pitch = Float(applyJoystickCurve(position: report.y, range: size.width/2) * 0.05)
         })
         
+        rightJoystickView.tappedBlock = {
+            Key_Event(Int32(K_CTRL.rawValue), qboolean(1), qboolean(1))
+            Key_Event(Int32(K_CTRL.rawValue), qboolean(0), qboolean(1))
+        }
+        
         rightJoystickView.movable = false
         rightJoystickView.alpha = 0.75
         rightJoystickView.baseAlpha = 0.25 // let the background bleed thru the base

--- a/Quake2-iOS/SDL_uikitviewcontroller+Additions.swift
+++ b/Quake2-iOS/SDL_uikitviewcontroller+Additions.swift
@@ -268,75 +268,75 @@ extension SDL_uikitviewcontroller {
 
     
     @objc func firePressed(sender: UIButton!) {
-        Key_Event(137, qboolean(1), qboolean(1))
+        Key_Event(Int32(K_CTRL.rawValue), qboolean(1), qboolean(1))
     }
     
     @objc func fireReleased(sender: UIButton!) {
-        Key_Event(137, qboolean(0), qboolean(1))
+        Key_Event(Int32(K_CTRL.rawValue), qboolean(0), qboolean(1))
     }
     
     @objc func jumpPressed(sender: UIButton!) {
-        Key_Event(32, qboolean(1), qboolean(1))
+        Key_Event(Int32(K_SPACE.rawValue), qboolean(1), qboolean(1))
     }
     
     @objc func jumpReleased(sender: UIButton!) {
-        Key_Event(32, qboolean(0), qboolean(1))
+        Key_Event(Int32(K_SPACE.rawValue), qboolean(0), qboolean(1))
     }
     
     @objc func tildePressed(sender: UIButton!) {
-//        Key_Event(32, qboolean(1), qboolean(1))
+//        Key_Event(Int32(K_SPACE.rawValue), qboolean(1), qboolean(1))
     }
     
     @objc func tildeReleased(sender: UIButton!) {
-//        Key_Event(32, qboolean(0), qboolean(1))
+//        Key_Event(Int32(K_SPACE.rawValue), qboolean(0), qboolean(1))
     }
     
     @objc func escapePressed(sender: UIButton!) {
-        Key_Event(27, qboolean(1), qboolean(1))
+        Key_Event(Int32(K_ESCAPE.rawValue), qboolean(1), qboolean(1))
     }
     
     @objc func escapeReleased(sender: UIButton!) {
-        Key_Event(27, qboolean(0), qboolean(1))
+        Key_Event(Int32(K_ESCAPE.rawValue), qboolean(0), qboolean(1))
     }
     
     @objc func quickSavePressed(sender: UIButton!) {
-        Key_Event(150, qboolean(1), qboolean(1))
+        Key_Event(Int32(K_F6.rawValue), qboolean(1), qboolean(1))
     }
     
     @objc func quickSaveReleased(sender: UIButton!) {
-        Key_Event(150, qboolean(0), qboolean(1))
+        Key_Event(Int32(K_F6.rawValue), qboolean(0), qboolean(1))
     }
     
     @objc func quickLoadPressed(sender: UIButton!) {
-        Key_Event(153, qboolean(1), qboolean(1))
+        Key_Event(Int32(K_F9.rawValue), qboolean(1), qboolean(1))
     }
     
     @objc func quickLoadReleased(sender: UIButton!) {
-        Key_Event(153, qboolean(0), qboolean(1))
+        Key_Event(Int32(K_F9.rawValue), qboolean(0), qboolean(1))
     }
     
     @objc func f1Pressed(sender: UIButton!) {
-        Key_Event(145, qboolean(1), qboolean(1))
+        Key_Event(Int32(K_F1.rawValue), qboolean(1), qboolean(1))
     }
     
     @objc func f1Released(sender: UIButton!) {
-        Key_Event(145, qboolean(0), qboolean(1))
+        Key_Event(Int32(K_F1.rawValue), qboolean(0), qboolean(1))
     }
     
     @objc func prevWeaponPressed(sender: UIButton!) {
-        Key_Event(183, qboolean(1), qboolean(1))
+        Key_Event(Int32(K_MWHEELDOWN.rawValue), qboolean(1), qboolean(1))
     }
     
     @objc func prevWeaponReleased(sender: UIButton!) {
-        Key_Event(183, qboolean(0), qboolean(1))
+        Key_Event(Int32(K_MWHEELDOWN.rawValue), qboolean(0), qboolean(1))
     }
     
     @objc func nextWeaponPressed(sender: UIButton!) {
-        Key_Event(184, qboolean(1), qboolean(1))
+        Key_Event(Int32(K_MWHEELUP.rawValue), qboolean(1), qboolean(1))
     }
     
     @objc func nextWeaponReleased(sender: UIButton!) {
-        Key_Event(184, qboolean(0), qboolean(1))
+        Key_Event(Int32(K_MWHEELUP.rawValue), qboolean(0), qboolean(1))
     }
 
 

--- a/Quake2-iOS/SavedGameViewController.swift
+++ b/Quake2-iOS/SavedGameViewController.swift
@@ -69,15 +69,6 @@ extension SavedGameViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         selectedSavedGame = saves[indexPath.row]
         loadGameButton.isHidden = false
-        #if os(tvOS)
-            tableView.cellForRow(at: indexPath)?.contentView.backgroundColor = .lightGray
-        #endif
-    }
-
-    func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
-        #if os(tvOS)
-            tableView.cellForRow(at: indexPath)?.contentView.backgroundColor = .none
-        #endif
     }
     
     //    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -95,9 +86,11 @@ extension SavedGameViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell")!
         
         cell.textLabel?.text = saves[indexPath.row]//.replacingOccurrences(of: ".svg", with: "")
-        #if os(tvOS)
-            cell.textLabel?.textColor = .black
-        #endif
+        cell.textLabel?.textColor = .white
+        cell.backgroundColor = .clear
+        cell.selectedBackgroundView = UIView.init(frame: .zero)
+        cell.selectedBackgroundView?.backgroundColor = UIColor.init(white: 1, alpha: 0.2)
+        cell.selectedBackgroundView?.layer.cornerRadius = 10
         return cell
     }
     

--- a/Quake2-tvOS/Main.storyboard
+++ b/Quake2-tvOS/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="14460.31" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="appleTV" orientation="landscape">
-        <adaptation id="light"/>
-    </device>
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="18122" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="appleTV" appearance="light"/>
     <dependencies>
         <deployment identifier="tvOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -34,7 +32,7 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Eor-e5-7M8">
-                                <rect key="frame" x="1370" y="60" width="440" height="292"/>
+                                <rect key="frame" x="1384" y="60" width="440" height="292"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="q u a k e  ii" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i1s-G9-Y44">
                                         <rect key="frame" x="0.0" y="0.0" width="440" height="85"/>
@@ -54,7 +52,7 @@
                                         <color key="textColor" red="0.52561199670000003" green="0.86642056700000003" blue="0.69806873800000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tdG-Gj-xg9">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tdG-Gj-xg9">
                                         <rect key="frame" x="0.0" y="85" width="440" height="69"/>
                                         <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="48"/>
                                         <state key="normal" title="new game">
@@ -64,7 +62,7 @@
                                             <segue destination="h0z-nt-sVd" kind="show" id="tvD-Vk-2Ys"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aSs-6i-98s">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aSs-6i-98s">
                                         <rect key="frame" x="0.0" y="154" width="440" height="69"/>
                                         <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="48"/>
                                         <state key="normal" title="load game">
@@ -74,7 +72,7 @@
                                             <segue destination="3mE-73-FRT" kind="show" id="w5G-xU-cO0"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vcJ-eO-fk8">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vcJ-eO-fk8">
                                         <rect key="frame" x="0.0" y="223" width="440" height="69"/>
                                         <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="48"/>
                                         <state key="normal" title="demo">
@@ -87,6 +85,7 @@
                                 </subviews>
                             </stackView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="qC1-tp-PXt"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="trailingMargin" secondItem="Eor-e5-7M8" secondAttribute="trailing" id="0NW-eb-wha"/>
@@ -97,7 +96,6 @@
                             </constraint>
                             <constraint firstAttribute="bottom" secondItem="WE9-jb-ZdU" secondAttribute="bottom" id="hwM-co-d4n"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="qC1-tp-PXt"/>
                     </view>
                     <navigationItem key="navigationItem" id="bJL-Du-FQP"/>
                     <connections>
@@ -130,12 +128,13 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="loading" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iOI-0W-Afg">
-                                <rect key="frame" x="94" y="983" width="241" height="87"/>
+                                <rect key="frame" x="84" y="983" width="241" height="87"/>
                                 <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="74"/>
                                 <color key="textColor" red="0.52561199670000003" green="0.86642056700000003" blue="0.69806873800000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="0Y3-kc-ye4"/>
                         <color key="backgroundColor" red="0.52561199670000003" green="0.86642056700000003" blue="0.69806873800000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="iOI-0W-Afg" secondAttribute="bottom" constant="10" id="4WM-ih-oce"/>
@@ -145,7 +144,6 @@
                             <constraint firstItem="12b-vS-7K6" firstAttribute="leading" secondItem="zay-pc-Dpq" secondAttribute="leading" id="bdI-Zw-OIt"/>
                             <constraint firstItem="12b-vS-7K6" firstAttribute="centerY" secondItem="zay-pc-Dpq" secondAttribute="centerY" id="rw7-rJ-Efc"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="0Y3-kc-ye4"/>
                     </view>
                     <connections>
                         <outlet property="backgroundImage" destination="12b-vS-7K6" id="qOv-XR-bzJ"/>
@@ -192,9 +190,9 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="f0f-y2-c2z">
-                                <rect key="frame" x="849" y="385" width="222" height="311"/>
+                                <rect key="frame" x="849" y="384.5" width="222" height="311"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="phz-D5-rfO">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="phz-D5-rfO">
                                         <rect key="frame" x="44" y="0.0" width="134" height="97"/>
                                         <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="72"/>
                                         <state key="normal" title="easy">
@@ -204,7 +202,7 @@
                                             <action selector="easyDifficulty:" destination="h0z-nt-sVd" eventType="primaryActionTriggered" id="SWc-lL-ahr"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FyM-ch-HqE">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FyM-ch-HqE">
                                         <rect key="frame" x="0.0" y="107" width="222" height="97"/>
                                         <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="72"/>
                                         <state key="normal" title="normal">
@@ -214,8 +212,8 @@
                                             <action selector="normalDifficulty:" destination="h0z-nt-sVd" eventType="primaryActionTriggered" id="oLS-CO-wj9"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8TW-h4-0A4">
-                                        <rect key="frame" x="39" y="214" width="145" height="97"/>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8TW-h4-0A4">
+                                        <rect key="frame" x="38.5" y="214" width="145" height="97"/>
                                         <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="72"/>
                                         <state key="normal" title="hard">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -227,6 +225,7 @@
                                 </subviews>
                             </stackView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="jIC-8m-7cF"/>
                         <color key="backgroundColor" red="0.52561199670000003" green="0.86642056700000003" blue="0.69806873800000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="clm-3X-Zgg" firstAttribute="leading" secondItem="BgP-W1-HJj" secondAttribute="leading" id="DBE-Hm-WBC"/>
@@ -236,7 +235,6 @@
                             <constraint firstItem="f0f-y2-c2z" firstAttribute="centerY" secondItem="BgP-W1-HJj" secondAttribute="centerY" id="plM-VI-Tk2"/>
                             <constraint firstItem="clm-3X-Zgg" firstAttribute="centerX" secondItem="BgP-W1-HJj" secondAttribute="centerX" id="teV-hu-B6B"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="jIC-8m-7cF"/>
                     </view>
                     <connections>
                         <outlet property="backgroundImage" destination="clm-3X-Zgg" id="oft-1T-MfX"/>
@@ -253,7 +251,7 @@
         <!--Saved Game View Controller-->
         <scene sceneID="FL6-d0-LGm">
             <objects>
-                <viewController id="3mE-73-FRT" customClass="SavedGameViewController" customModule="RTCW_SP_tvOS" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="3mE-73-FRT" customClass="SavedGameViewController" customModule="Quake2_tvOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="s2z-pn-jqI"/>
                         <viewControllerLayoutGuide type="bottom" id="M8g-TW-8wR"/>
@@ -266,8 +264,9 @@
                                 <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                             </imageView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="3sX-c9-5ah">
-                                <rect key="frame" x="110" y="80" width="1200" height="775"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <rect key="frame" x="100" y="80" width="1200" height="775"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="775" id="LnR-ZG-aZ4"/>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1200" id="cOp-jy-8Jj"/>
@@ -280,8 +279,8 @@
                                     <outlet property="delegate" destination="3mE-73-FRT" id="C23-7u-gLm"/>
                                 </connections>
                             </tableView>
-                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ue8-Yw-jCH">
-                                <rect key="frame" x="1318" y="80" width="129" height="59"/>
+                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ue8-Yw-jCH">
+                                <rect key="frame" x="1308" y="80" width="129" height="59"/>
                                 <fontDescription key="fontDescription" name="DpQuake" family="DpQuake" pointSize="40"/>
                                 <size key="titleShadowOffset" width="1" height="1"/>
                                 <state key="normal" title="LOAD">
@@ -292,6 +291,7 @@
                                 </connections>
                             </button>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="gAB-dP-Ik6"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="3sX-c9-5ah" firstAttribute="leading" secondItem="gAB-dP-Ik6" secondAttribute="leading" constant="20" id="0Co-9f-fIj"/>
@@ -306,7 +306,6 @@
                             <constraint firstItem="k81-eM-yLI" firstAttribute="width" secondItem="k81-eM-yLI" secondAttribute="height" multiplier="16:9" id="r6e-Yj-eZa"/>
                             <constraint firstItem="ue8-Yw-jCH" firstAttribute="leading" secondItem="3sX-c9-5ah" secondAttribute="trailing" constant="8" id="x0e-uF-r3k"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="gAB-dP-Ik6"/>
                     </view>
                     <connections>
                         <outlet property="loadGameButton" destination="ue8-Yw-jCH" id="kEi-CN-VOv"/>
@@ -318,10 +317,10 @@
             <point key="canvasLocation" x="-1205" y="2794"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="vu2-zQ-5dr"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <image name="quake2background" width="1920" height="1080"/>
     </resources>
-    <inferredMetricsTieBreakers>
-        <segue reference="ogQ-yk-2f9"/>
-    </inferredMetricsTieBreakers>
 </document>

--- a/Quake2/client/cl_input.c
+++ b/Quake2/client/cl_input.c
@@ -472,18 +472,19 @@ CL_BaseMove(usercmd_t *cmd)
         cmd->sidemove -= cl_sidespeed->value * CL_KeyState(&in_left);
     }
     
-    cmd->sidemove += cl_joyscale_x[0] * 2.0f * CL_KeyState(&in_moveright);
-    cmd->sidemove -= cl_joyscale_x[1] * 2.0f * CL_KeyState(&in_moveleft);
+    cmd->sidemove += cl_joyscale.strafe * 2.0f * CL_KeyState(&in_moveright);
+    cmd->sidemove -= cl_joyscale.strafe * 2.0f * CL_KeyState(&in_moveleft);
     
-    cl.viewangles[YAW] -= cl_joyscale_x[0];
+    cl.viewangles[YAW] -= cl_joyscale.yaw;
+    cl.viewangles[PITCH] -= cl_joyscale.pitch;
     
     cmd->upmove = cl_upspeed->value * CL_KeyState(&in_up);
     cmd->upmove -= cl_upspeed->value * CL_KeyState(&in_down);
     
     if (!(in_klook.state & 1))
     {
-        cmd->forwardmove += cl_joyscale_y[0] * 4.0f * CL_KeyState(&in_forward);
-        cmd->forwardmove -= cl_joyscale_y[1] * 4.0f * CL_KeyState(&in_back);
+        cmd->forwardmove += cl_joyscale.walk * 4.0f * CL_KeyState(&in_forward);
+        cmd->forwardmove -= cl_joyscale.walk * 4.0f * CL_KeyState(&in_back);
     }
 #else
 	if (in_strafe.state & 1)

--- a/Quake2/client/header/client.h
+++ b/Quake2/client/header/client.h
@@ -256,8 +256,12 @@ extern client_static_t	cls;
 extern int num_power_sounds;
 
 #ifdef IOS
-int cl_joyscale_x[2];
-int cl_joyscale_y[2];
+struct cl_joyscale_t {
+    float yaw;
+    float pitch;
+    float walk;
+    float strafe;
+} cl_joyscale;
 #endif
 
 /* cvars */

--- a/Quake2/client/vid/glimp_sdl.m
+++ b/Quake2/client/vid/glimp_sdl.m
@@ -380,7 +380,8 @@ GLimp_InitGraphics(int fullscreen, int *pwidth, int *pheight)
 
     [rootVC.view addSubview:[rootVC fireButtonWithRect:[rootVC.view frame]]];
     [rootVC.view addSubview:[rootVC jumpButtonWithRect:[rootVC.view frame]]];
-    [rootVC.view addSubview:[rootVC joyStickWithRect:[rootVC.view frame]]];
+    [rootVC.view addSubview:[rootVC leftJoyStickWithRect:[rootVC.view frame]]];
+    [rootVC.view addSubview:[rootVC rightJoyStickWithRect:[rootVC.view frame]]];
     [rootVC.view addSubview:[rootVC buttonStackWithRect:[rootVC.view frame]]];
     [rootVC.view addSubview:[rootVC f1ButtonWithRect:[rootVC.view frame]]];
     [rootVC.view addSubview:[rootVC prevWeaponButtonWithRect:[rootVC.view frame]]];


### PR DESCRIPTION
Hi! A few proposed changes here:

1. A trivial one first: tweaked the appearance of the saved game list, so that it has a transparent background, and selected items have a semitransparent white background with rounded border,
2. Updated joystick library to latest from bradhowes/Joystick,
3. Implemented dual joysticks with standard scheme - left controls forward and sideways motion, right controls pitch and yaw,
4. Adjusted joystick control curve from linear to power curve for more natural control,
5. Revised joystick to use relative, rather than absolute position, for control, meaning it's less critical where the first touch occurs,
6. Added tap on right joystick to fire,
7. Tweaked control system in cl_input.c for smoother movement,
8. Addressed an iOS quirk that caused random delays to the touch end event, causing mayhem